### PR TITLE
changed default value of transpose in load_data() function

### DIFF
--- a/samalg/__init__.py
+++ b/samalg/__init__.py
@@ -359,7 +359,7 @@ class SAM(object):
     def load_data(
         self,
         filename,
-        transpose=True,
+        transpose=False,
         save_sparse_file=None,
         sep=",",
         calculate_avg=False,


### PR DESCRIPTION
changed default value of transpose to False to correct sam behavior at quickstart.ipynb 